### PR TITLE
adds interceptor to RestClient instead of manual rewriting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>guava</artifactId>
             <version>17.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.3</version>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/src/main/java/uk/co/taidev/experiments/correlationidasync/Application.java
+++ b/src/main/java/uk/co/taidev/experiments/correlationidasync/Application.java
@@ -1,14 +1,19 @@
 package uk.co.taidev.experiments.correlationidasync;
 
+import org.apache.http.client.*;
+import org.apache.http.impl.client.*;
+import org.apache.http.impl.conn.*;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.*;
+import org.springframework.web.client.*;
 import uk.co.taidev.experiments.correlationidasync.web.filters.CorrelationHeaderFilter;
 
-import java.util.Arrays;
+import java.util.*;
 
 @Configuration
 @EnableAutoConfiguration
@@ -28,5 +33,22 @@ public class Application {
 
         return filterRegBean;
     }
+
+	@Bean
+	public HttpClient httpClient() {
+		return HttpClients.custom().setConnectionManager(new PoolingHttpClientConnectionManager()).build();
+	}
+
+	@Bean
+	public ClientHttpRequestFactory clientHttpRequestFactory() {
+		return new HttpComponentsClientHttpRequestFactory(httpClient());
+	}
+
+	@Bean
+	public RestTemplate restTemplate() {
+		RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory());
+		restTemplate.setInterceptors(Collections.singletonList(new CorrelationHeaderInterceptor()));
+		return restTemplate;
+	}
 
 }

--- a/src/main/java/uk/co/taidev/experiments/correlationidasync/CorrelationHeaderInterceptor.java
+++ b/src/main/java/uk/co/taidev/experiments/correlationidasync/CorrelationHeaderInterceptor.java
@@ -1,0 +1,20 @@
+package uk.co.taidev.experiments.correlationidasync;
+
+import org.springframework.http.*;
+import org.springframework.http.client.*;
+import uk.co.taidev.experiments.correlationidasync.reporting.*;
+
+import java.io.*;
+
+public class CorrelationHeaderInterceptor implements ClientHttpRequestInterceptor {
+
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws
+			IOException {
+
+		HttpHeaders headers = request.getHeaders();
+		headers.add(RequestCorrelation.CORRELATION_ID_HEADER, RequestCorrelation.getId());
+		return execution.execute(request, body);
+	}
+}

--- a/src/main/java/uk/co/taidev/experiments/correlationidasync/web/client/CorrelatingRestClient.java
+++ b/src/main/java/uk/co/taidev/experiments/correlationidasync/web/client/CorrelatingRestClient.java
@@ -2,6 +2,7 @@ package uk.co.taidev.experiments.correlationidasync.web.client;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -18,20 +19,22 @@ public class CorrelatingRestClient implements RestClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CorrelatingRestClient.class);
 
-    private RestTemplate restTemplate = new RestTemplate();
+	private RestTemplate restTemplate;
 
+	@Autowired
+	public CorrelatingRestClient( RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+	}
 
-    @Override
+	@Override
     public String getForString(String uri) {
         String correlationId = RequestCorrelation.getId();
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(RequestCorrelation.CORRELATION_ID_HEADER, correlationId);
 
         LOGGER.info("start REST request to {} with correlationId {}", uri, correlationId);
 
         //TODO: error-handling and fault-tolerance in production
         ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.GET,
-                new HttpEntity<String>(httpHeaders), String.class);
+                new HttpEntity<String>(new HttpHeaders()), String.class);
 
         LOGGER.info("completed REST request to {} with correlationId {}", uri, correlationId);
 


### PR DESCRIPTION
I've added Interceptor to automatically add CorrelationIDs headers to each RestTemplate reqest. Should work. I hope.
